### PR TITLE
fix nasty bug that makes the sensor unreadable

### DIFF
--- a/examples/ColorSensor/ColorSensor.ino
+++ b/examples/ColorSensor/ColorSensor.ino
@@ -24,21 +24,22 @@ void setup() {
 
 void loop() {
   // check if a color reading is available
-  if (APDS.colorAvailable()) {
-    int r, g, b;
-
-    // read the color
-    APDS.readColor(r, g, b);
-
-    // print the values
-    Serial.print("r = ");
-    Serial.println(r);
-    Serial.print("g = ");
-    Serial.println(g);
-    Serial.print("b = ");
-    Serial.println(b);
-    Serial.println();
+  while (! APDS.colorAvailable()) {
+    delay(5);
   }
+  int r, g, b;
+
+  // read the color
+  APDS.readColor(r, g, b);
+
+  // print the values
+  Serial.print("r = ");
+  Serial.println(r);
+  Serial.print("g = ");
+  Serial.println(g);
+  Serial.print("b = ");
+  Serial.println(b);
+  Serial.println();
 
   // wait a bit before reading again
   delay(1000);


### PR DESCRIPTION
Your version of the example works fine in this "hello world" format. But if you try to use this library in a real life scenario, in a program that uses other sensors, other libraries, etc,, it fails. See here:

https://forum.arduino.cc/index.php?topic=642174.0

The reason for the failure is - there  needs to be a very brief pause between colorAvailable() and readColor(). Without that pause, in more complex programs, the second function call fails.

Take a look at the similar example that comes with the Adafruit version of the APDS9960 library. It uses the delay(), and for good reason - their code works no matter what, whereas the version you provide (without delay()) only works in this hello world example.

The change I propose implements the mandatory delay() between the two function calls. With this change, the sensor can always be read.