### PR TITLE
Adding Reference Link to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,8 @@
 
 A library for the APDS9960 sensor, allows you to read gestures, color, and proximity on your Arduino Nano 33 BLE Sense board and other boards with sensor attached via I2C.
 
+For more information about this library please visit us at https://www.arduino.cc/en/Reference/ArduinoAPDS9960
+
 == License ==
 
 Copyright (c) 2019 Arduino SA. All rights reserved.


### PR DESCRIPTION
Inserted the missing reference link to the library page at [arduino.cc](https://www.arduino.cc/en/Reference/ArduinoAPDS9960)