### PR TITLE
Fix CI build for megaavr by removing ambiguity for requestFrom call.

### DIFF
--- a/src/Arduino_APDS9960.cpp
+++ b/src/Arduino_APDS9960.cpp
@@ -258,7 +258,7 @@ bool APDS9960::read(uint8_t reg, uint8_t *val) {
 size_t APDS9960::readBlock(uint8_t reg, uint8_t *val, unsigned int len) {
     size_t i = 0;
     if (!write(reg)) return 0;
-    _wire.requestFrom(APDS9960_ADDR, len);
+    _wire.requestFrom((uint8_t)APDS9960_ADDR, len);
     while (_wire.available()) {
       if (i == len) return 0;
       val[i++] = _wire.read();


### PR DESCRIPTION
This is done by making it clear to the compiler that the constant defining the address is in fact a uint8_t.