### PR TITLE
Revert readme regressions introduced with reference link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,3 +8,5 @@ image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 A library for the APDS-9960 sensor, allows you to read gestures, color, and proximity on your Arduino Nano 33 BLE Sense board and other boards with sensor attached via I2C.
+
+For more information about this library please visit us at https://www.arduino.cc/en/Reference/ArduinoAPDS9960

--- a/README.adoc
+++ b/README.adoc
@@ -1,23 +1,10 @@
-= APDS9960 Library for Arduino =
+:repository-owner: arduino-libraries
+:repository-name: Arduino_APDS9960
 
-A library for the APDS9960 sensor, allows you to read gestures, color, and proximity on your Arduino Nano 33 BLE Sense board and other boards with sensor attached via I2C.
+= {repository-name} Library for Arduino =
 
-For more information about this library please visit us at https://www.arduino.cc/en/Reference/ArduinoAPDS9960
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml/badge.svg["Check Arduino status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml"]
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml/badge.svg["Compile Examples status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml"]
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
-== License ==
-
-Copyright (c) 2019 Arduino SA. All rights reserved.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+A library for the APDS-9960 sensor, allows you to read gestures, color, and proximity on your Arduino Nano 33 BLE Sense board and other boards with sensor attached via I2C.

--- a/README.adoc
+++ b/README.adoc
@@ -9,4 +9,4 @@ image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/
 
 A library for the APDS-9960 sensor, allows you to read gestures, color, and proximity on your Arduino Nano 33 BLE Sense board and other boards with sensor attached via I2C.
 
-For more information about this library please visit us at https://www.arduino.cc/en/Reference/ArduinoAPDS9960
+For more information about this library please visit us at https://www.arduino.cc/reference/en/libraries/arduino_apds9960/


### PR DESCRIPTION
A significant regression was inadvertently introduced by https://github.com/arduino-libraries/Arduino_APDS9960/commit/34f47af297b7863442f83dfba47242c2b1efee60, which was only intended to add a link
to the library reference (https://github.com/arduino-libraries/Arduino_APDS9960/pull/9).

The regressions are here removed, while retaining the updated link to the library reference.