### PR TITLE
Fix spell check false positive by ignoring word

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = ,
+ignore-words-list = totaly
 check-filenames =
 check-hidden =
 skip = ./.git


### PR DESCRIPTION
In the latest release of [the **codespell** tool](https://github.com/codespell-project/codespell) used for automated spell checking of the files of this project, the word "totaly" was added to the **codespell** misspelled words dictionary as a misspelling of "totally".

This caused a false detection of the variable name `totalY` as a misspelling, resulting in a failing spell check result:

https://github.com/arduino-libraries/Arduino_APDS9960/runs/7968573430?check_suite_focus=true#step:4:17

```text
Error: ./src/Arduino_APDS9960.cpp:305: totalY ==> totally
Error: ./src/Arduino_APDS9960.cpp:309: totalY ==> totally
Error: ./src/Arduino_APDS9960.cpp:312: totalY ==> totally
Error: ./src/Arduino_APDS9960.cpp:313: totalY ==> totally
```

Since the occurrences of this word are correct and intended in this project, the false positive is resolved by configuring codespell to ignore the problematic word.